### PR TITLE
Fixed sass imports

### DIFF
--- a/css/overrides.scss
+++ b/css/overrides.scss
@@ -4,14 +4,15 @@ sass/config/variables stuff
 $font-prefix: '../node_modules/@ibm/plex/';
 @import 'node_modules/@ibm/plex/scss/ibm-plex.scss';
 // these sass variables aren't all working (at least color isn't)
-$color-primary: #0050d8;
+
+// MADE IT RED SO WE CAN SEE IT WORKING A LOT
+// $color-primary: #0050d8;
+$color-primary: red;
+
 $font-sans: 'IBM Plex Sans', sans-serif;
 
-// not sure if these need to be here?
-// @import "../node_modules/us-forms-system/src/scss/base/_b-variables";
-// @import '../node_modules/uswds/src/stylesheets/core/variables';
-
-@import '../node_modules/us-forms-system/lib/css/styles.css';
+$asset-path: '../node_modules/uswds/src/';
+@import '../node_modules/us-forms-system/src/scss/styles.scss';
 
 /*
 general/global overrides,

--- a/package.json
+++ b/package.json
@@ -64,5 +64,10 @@
     "react-location-picker": "^1.3.0",
     "us-forms-system": "^1.1.0",
     "uswds": "^1.6.3"
+  },
+  "prettier": {
+    "semi": true,
+    "singleQuote": true,
+    "trailingComma": "all"
   }
 }


### PR DESCRIPTION
Did a bit of digging and found this: https://github.com/uswds/uswds/pull/2365
So after setting that sass var the imports in uswds started working correctly and now we should be able to do var overrides

Also I added the prettier config to the project so we don't have our defaults fighting each other