### PR TITLE
Added supplemental build process for component dependencies.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Directories to ignore
 node_modules/
 .babelcache/
+.usfs/
 build/
 
 # Build artifacts

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "app.js",
   "directories": {},
   "scripts": {
+    "refresh": "./scripts/refresh.sh",
     "start": "webpack-dev-server --open --config webpack.dev.js",
     "build": "webpack --config webpack.prod.js",
     "lint": "eslint --quiet --ext .js --ext .jsx .",

--- a/scripts/refresh.sh
+++ b/scripts/refresh.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+WORKSPACE_NANE=".usfs"
+INITIAL_DIR="${PWD}"
+API_URL_DEFAULT="https://localhost:5000";
+
+function print_messasge_block {
+	echo "------------------------------------------------------"
+	echo -e "--- ${1}"
+	echo "--- ${PWD}"
+ 	echo "------------------------------------------------------"
+}
+
+if [ "${API_URL}" = "" ]; then
+  export API_URL=$API_URL_DEFAULT
+  print_messasge_block "Required environment API_URL is not set.\nExporting default value: ${API_URL_DEFAULT}";
+fi;
+
+print_messasge_block "API_URL: ${API_URL}"
+
+#
+# Downloads a dependency from github
+#
+function download_repo {
+	REPO=$1
+	print_messasge_block "Downloading repo: '${REPO}'"
+	{
+		git clone https://github.com/cityofaustin/$REPO.git
+	} || {
+		echo "Repo already exists: ${REPO}"
+	}
+}
+
+
+#
+# Builds the repo (and copy output into dependency)
+# $1 : String : the name of the repo
+# $2..$n: String : the name of library that depends on $1
+#
+function build_repo {
+	REPO=$1
+
+	print_messasge_block "Building repo: '${REPO}'"
+
+	cd "./${REPO}";
+
+	echo "${PWD}";
+
+	yarn;
+
+
+	# Iterate for each dependency (if any)
+	for i in "${@:2}"
+	do
+	    DEPENDENCY=$i
+	    echo "	> Building: ${REPO}"
+		echo "	> Repo's Dependency: '${DEPENDENCY}'"
+		DEPENDENCY_BUILD="../${DEPENDENCY}/build/index.js"
+		DEPENDENCY_DESTINATION="node_modules/@cityofaustin/$DEPENDENCY/build"
+		echo "		>> Current Working Dir: '${PWD}'"
+		echo "		>> Copying dependency: '${DEPENDENCY_BUILD}'"
+		echo "		>> Into dependency path: '${DEPENDENCY_DESTINATION}'"
+		cp 	$DEPENDENCY_BUILD $DEPENDENCY_DESTINATION
+	done
+
+
+	print_messasge_block "Building (yarn build) repo: ${REPO}"
+
+	yarn build;
+
+	print_messasge_block "Done"
+
+	cd ..
+}
+
+#
+# Extracts build output from $1..$n dependencies
+# $1..$n : String : The name of the repo
+#
+function extract_libraries {
+	print_messasge_block "Extracting Libraries"
+	# Iterate for each dependency (if any)
+	for DEPENDENCY in "${@}"
+	do
+		DEPENDENCY_BUILD="${WORKSPACE_NANE}/${DEPENDENCY}/build/index.js"
+		DEPENDENCY_DESTINATION="node_modules/@cityofaustin/$DEPENDENCY/build"
+		echo -e "\n		>> Dependency: '${DEPENDENCY}'"
+		echo "		>> Current Working Dir: '${PWD}'"
+		echo "		>> Copying dependency: '${DEPENDENCY_BUILD}'"
+		echo "		>> Into dependency path: '${DEPENDENCY_DESTINATION}'"
+		cp 	$DEPENDENCY_BUILD $DEPENDENCY_DESTINATION
+	done
+}
+
+#
+# Try to create the '.usfs' cache folder, or output existing message.
+#
+{
+	mkdir "${WORKSPACE_NANE}";
+} || {
+	echo "Workspace already exists: ${WORKSPACE_NANE}"
+}
+
+cd "${WORKSPACE_NANE}";
+print_messasge_block "Switched Workspace"
+
+
+#
+# First we download the repos
+#
+download_repo "usfs-components";
+download_repo "officer-form-chapters";
+
+
+#
+# Then we build them
+#
+build_repo "usfs-components"
+build_repo "officer-form-chapters" "usfs-components"
+
+# Move back to the initial working directory
+cd "${INITIAL_DIR}";
+
+
+#
+# Finally, we extract the build outputs into our current yarn project.
+#
+extract_libraries "usfs-components" "officer-form-chapters"
+
+echo -e "\n\n"


### PR DESCRIPTION
Hello friends,

As we may already know, we face a challenge within yarn when we import dependencies from GitHub, namely the repos "usfs-components" and "officer-form-chapters". The problem is that when the code is installed, the library is contained in build/index.js, which has to be compiled before it is imported.

I have not been able to figure out a way to install raw-code dependencies & build them during install, though I have tried using the `postinstall` yarn hook and other mechanisms, to no avail.

Having limited time, I came up with a shell script that can download, compile and install the latest repo code for us from those two repos.

### We do not need to have this script here, it could simply be part of our Travis build process.

### Yarn Refresh

Yarn refresh is the yarn hook that runs a shell script that downloads, builds and installs "usfs-components" and "officer-form-chapters" into our project "officer-complaint-form". We would need to have this 

The process would look like this:

```
$ git clone https://github.com/cityofaustin/officer-complaint-form.git

$ cd officer-complaint-form

$ yarn

$ yarn refresh

$ yarn start
```

### Process Basics:

The files/libraries are downloaded from repo into a cache folder `.usfs` which should be ignored by git. 

*Download process*
During the first execution, it takes a while (a few minutes) to download, install dependencies and build the library. After the first execution, everything is already cached and refreshing code should only take a few moments.

*Build Process*
The library follows a normal yarn build process. It runs yarn & yarn build. I understand the process is a bit redundant, but at least it provides a fresh build of the latest code in the repos.

*Installation*
The script will build the repos into `.usfs` and then extract the files built by webpack into each repo's corresponding folder.

