### PR TITLE
Added support for confirmation case number

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,7 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { Router, useRouterHistory } from "react-router";
 import { Provider } from "react-redux";
-import { createStore, combineReducers } from "redux";
+import { createStore, combineReducers, applyMiddleware } from "redux";
 import { createHistory } from "history";
 
 import "us-forms-system/lib/css/styles.css";
@@ -11,7 +11,9 @@ import "./css/overrides.scss";
 import route from "./js/routes.jsx";
 import reducer from "./js/reducers";
 
-const store = createStore(combineReducers(reducer));
+import thunk from 'redux-thunk';
+
+const store = createStore(combineReducers(reducer), applyMiddleware(thunk));
 
 const browserHistory = useRouterHistory(createHistory)({
   basename: ""

--- a/js/components/Confirmation.jsx
+++ b/js/components/Confirmation.jsx
@@ -6,11 +6,12 @@ import SegmentedProgressBar from "us-forms-system/lib/js/components/SegmentedPro
 
 class Confirmation extends React.Component {
   render() {
+    let confirmationCaseNumber = localStorage.getItem("opo_confirmation_case_number") || "N/A";
     return (
       <div className="schemaform-intro">
         <SegmentedProgressBar total={2} current={2}/>
         <h2 style={{textAlign: "center"}}>We have received your complaint.</h2>
-        <h3 style={{color: "#164ED2", textAlign: "center"}}>Your case number: 000-000-000</h3>
+        <h3 style={{color: "#164ED2", textAlign: "center"}}>Your case number: {confirmationCaseNumber}</h3>
         <p style={{fontSize: "1.4rem"}}>Our job is to make sure your complaint is investigated fairly and thoroughly. Thank you for sharing your experience with us. This helps us better serve you and your community.</p>
         <hr/>
         <p style={{fontSize: "1.4rem"}}>You will receive an email with a copy of your complaint and a confirmation number. You can email us at <a>policeoversight@austintexas.gov</a> or call us at <a>512-972-2676</a> with your confirmation number to find where your complaint is in this process.</p>

--- a/js/config/form.js
+++ b/js/config/form.js
@@ -12,13 +12,62 @@ import {
 } from './chapters';
 
 const formConfig = {
+  type: "complaint",
+  language: "en",
   title: 'File a complaint',
   subTitle: '',
   formId: '',
   urlPrefix: '/',
   trackingPrefix: 'form-',
-  transformForSubmit: '',
-  submitUrl: '',
+  transformForSubmit: (formConfig, form) => {
+    form.data.language = formConfig.language;
+    form.data.type = formConfig.type;
+    return JSON.stringify(form.data);
+  },
+  submit: (formData, formConfig) => {
+    console.log("Submitting:");
+    console.log(formData.data);
+
+  	// Create the XHR request
+  	var request = new XMLHttpRequest();
+  	// Return it as a Promise
+  	return new Promise(function (resolve, reject) {
+  		// Setup our listener to process compeleted requests
+  		request.onreadystatechange = function () {
+  			// Only run if the request is complete
+  			if (request.readyState !== 4) return;
+  			// Process the response
+  			if (request.status >= 200 && request.status < 300) {
+  				// If successful
+  				resolve(request);
+  			} else {
+  				// If failed
+  				reject({
+  					status: request.status,
+  					statusText: request.statusText
+  				});
+  			}
+  		};
+  		// Setup our HTTP request, headers & send our payload ...
+  		request.open('POST', formConfig.submitUrl, true);
+  		request.setRequestHeader("Content-Type", "application/json;charset=UTF-8");
+  		request.send(JSON.stringify(formData.data));
+  	})
+    .then(function (response) {
+      console.log("Success: ");
+      console.log(response.response);
+      let respObj = JSON.parse(response.response);
+      console.log(respObj.case_number);
+      localStorage.setItem("opo_confirmation_case_number", respObj.case_number);
+      return response;
+  	})
+  	.catch(function (error) {
+      console.log("Error: ");
+      console.log(error);
+      return error;
+  	});
+  },
+  submitUrl: `${process.env.API_URL}/form/submit`,
   introduction: Introduction,
   confirmation: Confirmation,
   defaultDefinitions: {},

--- a/js/config/form.js
+++ b/js/config/form.js
@@ -13,18 +13,18 @@ import {
 
 const formConfig = {
   type: "complaint",
-  language: "en",
+  language: "es",
   title: 'File a complaint',
   subTitle: '',
   formId: '',
   urlPrefix: '/',
   trackingPrefix: 'form-',
-  transformForSubmit: (formConfig, form) => {
-    form.data.language = formConfig.language;
-    form.data.type = formConfig.type;
-    return JSON.stringify(form.data);
-  },
   submit: (formData, formConfig) => {
+    console.log("Appending type and language to formData ...");
+    // First we have to append type and language
+    formData.data.language = formConfig.language;
+    formData.data.type = formConfig.type;
+
     console.log("Submitting:");
     console.log(formData.data);
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "react-filepond": "^5.0.0",
     "react-flatpickr": "^3.6.4",
     "react-location-picker": "^1.3.0",
-    "us-forms-system": "cityofaustin/us-forms-system#hacks-for-demo",
+    "redux-thunk": "^2.3.0",
+    "us-forms-system": "^1.2.0",
     "uswds": "^1.6.3"
   },
   "prettier": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2090,7 +2090,7 @@ classlist-polyfill@^1.0.3:
   resolved "https://registry.yarnpkg.com/classlist-polyfill/-/classlist-polyfill-1.2.0.tgz#935bc2dfd9458a876b279617514638bcaa964a2e"
   integrity sha1-k1vC39lFiodrJ5YXUUY4vKqWSi4=
 
-classnames@^2.2.6:
+classnames@^2.2.5, classnames@^2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
@@ -2637,7 +2637,7 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-date-fns@^1.29.0, date-fns@^1.30.1:
+date-fns@^1.30.1:
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
@@ -2900,7 +2900,7 @@ domready@^1.0.8:
   resolved "https://registry.yarnpkg.com/domready/-/domready-1.0.8.tgz#91f252e597b65af77e745ae24dd0185d5e26d58c"
   integrity sha1-kfJS5Ze2Wvd+dFriTdAYXV4m1Yw=
 
-downshift@^1.31.16:
+downshift@^1.22.5:
   version "1.31.16"
   resolved "https://registry.yarnpkg.com/downshift/-/downshift-1.31.16.tgz#acd81631539502d4112d01bd573654419fd9f640"
   integrity sha512-RskXmiGSoz0EHAyBrmTBGSLHg6+NYDGuLu2W3GpmuOe6hmZEWhCiQrq5g6DWzhnUaJD41xHbbfC6j1Fe86YqgA==
@@ -5716,6 +5716,11 @@ module-deps@^4.0.8:
     through2 "^2.0.0"
     xtend "^4.0.0"
 
+moment@^2.15.1:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -6941,6 +6946,11 @@ range-parser@^1.0.3, range-parser@~1.2.0:
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
   integrity sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=
 
+raven-js@^3.12.1:
+  version "3.27.0"
+  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.27.0.tgz#9f47c03e17933ce756e189f3669d49c441c1ba6e"
+  integrity sha512-vChdOL+yzecfnGA+B5EhEZkJ3kY3KlMzxEhShKh6Vdtooyl0yZfYNFQfYzgMf2v4pyQa+OTZ5esTxxgOOZDHqw==
+
 raw-body@2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.3.3.tgz#1b324ece6b5706e153855bc1148c65bb7f6ea0c3"
@@ -7102,7 +7112,7 @@ react-router@3:
     prop-types "^15.5.6"
     warning "^3.0.0"
 
-react-scroll@^1.7.10:
+react-scroll@^1.7.9:
   version "1.7.10"
   resolved "https://registry.yarnpkg.com/react-scroll/-/react-scroll-1.7.10.tgz#b59cfa11a899a362c6489607ed5865c9c5fd0b53"
   integrity sha512-7K1caXF19PQ/jck+QRCdRMytqWei1ktv7jtcsgMap2s55pGOUc/a5phr4loajZRFRx3qKj9Tz12KDtELp91xMg==
@@ -7308,6 +7318,11 @@ reduce-function-call@^1.0.1:
   integrity sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=
   dependencies:
     balanced-match "^0.4.2"
+
+redux-thunk@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
+  integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==
 
 redux@^3.5.2:
   version "3.7.2"
@@ -8810,19 +8825,21 @@ url@^0.11.0, url@~0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-us-forms-system@cityofaustin/us-forms-system#hacks-for-demo:
-  version "1.1.0"
-  resolved "https://codeload.github.com/cityofaustin/us-forms-system/tar.gz/065c8321decdf6a3afbdfe9067cb3e017c2a35f2"
+us-forms-system@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/us-forms-system/-/us-forms-system-1.2.0.tgz#ec482b7aef759c449a2a0647546ee85ddae7c122"
+  integrity sha512-Etreg+iuq/5wfWaJ5oNT1KpbT7RiyDhokNE9QMAG949ceXe2jZXzLqZl90lTimW779ZDf2xm2iDF3ZqxMbEqxg==
   dependencies:
     "@department-of-veterans-affairs/react-jsonschema-form" "^1.0.0"
-    classnames "^2.2.6"
-    date-fns "^1.29.0"
-    downshift "^1.31.16"
+    classnames "^2.2.5"
+    downshift "^1.22.5"
     fast-levenshtein "^2.0.6"
     history "3"
+    moment "^2.15.1"
+    raven-js "^3.12.1"
     react-redux "4.4.8"
     react-router "3"
-    react-scroll "^1.7.10"
+    react-scroll "^1.7.9"
     react-transition-group "^1.1.2"
     recompose "^0.21.2"
     redux "^3.5.2"


### PR DESCRIPTION
Changes for this PR: 

```
yarn add redux-thunk
```

From their repo:  "Redux Thunk middleware allows you to write action creators that return a function instead of an action. The thunk can be used to delay the dispatch of an action, or to dispatch only if a certain condition is met. The inner function receives the store methods dispatch and getState as parameters. [...] This is convenient for orchestrating an asynchronous control flow with thunk action creators dispatching each other and returning Promises to wait for each other’s completion"

```
let confirmationCaseNumber = localStorage.getItem("opo_confirmation_case_number") || "N/A";
```

I could not manage to pass props to this component via the form configuration, also I could not think of a way to access the form configuration from this component, not a lot of documentation is provided and cannot spend too much time on this. For now localStorage will suffice.

```
const formConfig = {
  type: "complaint",
  language: "en",
```

The backend API now supports multilanguage emails, but it needs to know in what language the form was served. These two values can be changed at any time, they are appended *before* submission.

```
transformForSubmit: (formConfig, form)
```

This is where the formConfig values are appended to the final json payload before submission.

```
submit: (formData, formConfig)
```

As per the USDS documentation, in order to customize the processing of data, this function needs to override the default with whatever custom process we have for it. The only condition is to return the request in the form of a Promise object.