### PR TITLE
Update Yarn Lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,17 @@ yarn link "@cityofaustin/usfs-components"
 
 By doing this, instead of using the version of the components from npm, your local form will use the linked version you can modify locally. We do not currently have live updating implemented, so when you want to see how your changes behave in the form you will need to run `yarn build` first.
 
-## Deploying
-*TODO*
+## Yarn Lock
 
-After encountering issues with heroku and travis, I decided to try out using GitLab for some deployment stuff. It's currently living here: https://gitlab.com/briaguya/officer-complaint-form but I'm more than open to changing it.
+*Keep the yarn.lock updated for every commit done to the dependency libraries.*  
+
+We encountered some issues of the forms building with outdated components, as a general rule of thumb, when referencing any repo in package.json, it is important to re-render `yarn.lock`. The quickest way to do this is by removing the library and adding it back through the yarn command, for example:
+
+```
+yarn remove "cityofaustin/us-forms-system"
+
+--and then--
+
+yarn add "cityofaustin/us-forms-system"
+```
+

--- a/js/config/form.js
+++ b/js/config/form.js
@@ -12,7 +12,7 @@ import {
 
 const formConfig = {
   type: "complaint",
-  language: "es",
+  language: "en",
   title: 'File a complaint',
   subTitle: '',
   formId: '',

--- a/yarn.lock
+++ b/yarn.lock
@@ -9094,7 +9094,7 @@ url@^0.11.0, url@~0.11.0:
 
 us-forms-system@cityofaustin/us-forms-system:
   version "1.1.0"
-  resolved "https://codeload.github.com/cityofaustin/us-forms-system/tar.gz/d8d14b77d8b1b85c96a002b2a3b41cc1187df32e"
+  resolved "https://codeload.github.com/cityofaustin/us-forms-system/tar.gz/ac0253cd1974245beeca7ca97f2315981a98a8c3"
   dependencies:
     "@department-of-veterans-affairs/react-jsonschema-form" "^1.0.0"
     classnames "^2.2.6"


### PR DESCRIPTION
This fixes the master branch locally, it looks like we didn't update yarn.lock whenever we removed the `sg-ocf-working` branch.

I could have run a hotfix on master, but I think I needed to run this by y'all.