### PR TITLE
fix "Date and time" translation on OPO form intro page

### DIFF
--- a/locale/translations.json
+++ b/locale/translations.json
@@ -599,7 +599,7 @@
     "es": ":%Nombre%"
   },
 
-  "%Date and time %": {
+  "%Date and time%": {
     "es": "%Fecha y hora%"
   },
 


### PR DESCRIPTION
@amenity I deleted the period at the end of `"%Date and time%"`; hopefully that fixes #1498