### PR TITLE
1686 review page button cutoff

### DIFF
--- a/css/overrides.scss
+++ b/css/overrides.scss
@@ -238,6 +238,7 @@ legend.schemaform-label {
 .accordion-header.clearfix.schemaform-chapter-accordion-header > button {
   color: #0050d8;
   font-weight: 500;
+  height: auto;
 }
 
 .filepond--root {

--- a/css/overrides.scss
+++ b/css/overrides.scss
@@ -239,6 +239,7 @@ legend.schemaform-label {
   color: #0050d8;
   font-weight: 500;
   height: auto;
+  padding: 1.5rem 4.5rem 1.5rem 1.5rem;
 }
 
 .filepond--root {


### PR DESCRIPTION
- implements CSS fix to allow for button text that spans more than 1 line to display without being cutoff 
- reduces button padding